### PR TITLE
Linux: add metainfo.xml

### DIFF
--- a/build/AppDir/usr/share/metainfo/io.github.maurycyliebner.enve.metainfo.xml
+++ b/build/AppDir/usr/share/metainfo/io.github.maurycyliebner.enve.metainfo.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>io.github.maurycyliebner.enve</id>
+  <launchable type="desktop-id">io.github.maurycyliebner.enve.desktop</launchable>
+  <name>enve</name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0</project_license>
+  <developer_name>Maurycy Liebner</developer_name>
+  <summary>2D animation</summary>
+  <description>
+    <p>
+      Flexible, user expandable 2D animation software for Linux and Windows.
+    </p>
+  </description>
+  <url type="homepage">https://maurycyliebner.github.io</url>
+  <url type="bugtracker">https://github.com/MaurycyLiebner/enve/issues</url>
+  <url type="donation">https://www.patreon.com/enve</url>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://user-images.githubusercontent.com/16670651/70745938-36e20900-1d25-11ea-9bdf-78d3fe402291.png</image>
+    </screenshot>
+  </screenshots>
+  <content_rating type="oars-1.1"/>
+  <releases>
+    <release version="0.0.0" date="2019-09-10"/>
+  </releases>
+</component>


### PR DESCRIPTION
Standard: https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

While I wrote this file while working on flatpak, this file is NOT flatpak specific, it's also used by regular distribution packages. It's needed to display useful informations in software managers like "GNOME Software" and "KDE Discover" or on [Flathub.org](https://www.flathub.org).