### PR TITLE
qmake: run git

### DIFF
--- a/.travis_linux_script.sh
+++ b/.travis_linux_script.sh
@@ -9,17 +9,6 @@ chmod +x AppRun
 wget https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so
 mv exec-x86_64.so exec.so
 cd Release
-
-# embed commit hash and date
-LATEST_COMMIT_HASH=\"$(git log --pretty=format:'%h' -n 1)\"
-enveSplash=../../src/app/GUI/envesplash.h
-echo "#ifndef LATEST_COMMIT_HASH" >> $enveSplash
-echo "#define LATEST_COMMIT_HASH $LATEST_COMMIT_HASH" >> $enveSplash
-echo "#endif" >> $enveSplash
-LATEST_COMMIT_DATE=\"$(git log -1 --format=%ai)\"
-echo "#ifndef LATEST_COMMIT_DATE" >> $enveSplash
-echo "#define LATEST_COMMIT_DATE $LATEST_COMMIT_DATE" >> $enveSplash
-echo "#endif" >> $enveSplash
 qmake PREFIX=$INSTALL_PREFIX CONFIG+=build_examples ../../enve.pro
 make -j 2 CC=gcc-7 CPP=g++-7 CXX=g++-7 LD=g++-7
 make install

--- a/.travis_osx_script.sh
+++ b/.travis_osx_script.sh
@@ -1,15 +1,5 @@
 cd build
 cd Release
-# embed commit hash and date
-LATEST_COMMIT_HASH=\"$(git log --pretty=format:'%h' -n 1)\"
-enveSplash=../../src/app/GUI/envesplash.h
-echo "#ifndef LATEST_COMMIT_HASH" >> $enveSplash
-echo "#define LATEST_COMMIT_HASH $LATEST_COMMIT_HASH" >> $enveSplash
-echo "#endif" >> $enveSplash
-LATEST_COMMIT_DATE=\"$(git log -1 --format=%ai)\"
-echo "#ifndef LATEST_COMMIT_DATE" >> $enveSplash
-echo "#define LATEST_COMMIT_DATE $LATEST_COMMIT_DATE" >> $enveSplash
-echo "#endif" >> $enveSplash
 qmake CONFIG+=build_examples ../../enve.pro
 make -j 2
 cd src/app

--- a/src/app/GUI/envesplash.cpp
+++ b/src/app/GUI/envesplash.cpp
@@ -69,7 +69,7 @@ void EnveSplash::drawContents(QPainter * const p) {
     const QString date(LATEST_COMMIT_DATE);
     rightTxt = QString(LATEST_COMMIT_HASH) + " " + date.split(" ").first();
 #else
-    rightTxt = "0.0.0";
+    rightTxt = ENVE_VERSION;
 #endif
     p->drawText(mBottomRect, Qt::AlignVCenter | Qt::AlignRight, rightTxt);
 }

--- a/src/app/XDGData/io.github.maurycyliebner.enve.metainfo.xml.in
+++ b/src/app/XDGData/io.github.maurycyliebner.enve.metainfo.xml.in
@@ -22,6 +22,6 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release version="0.0.0" date="2019-09-10"/>
+    <release version="@METAINFO_RELEASE_VERSION@" date="@METAINFO_RELEASE_DATE@"/>
   </releases>
 </component>

--- a/src/app/app.pro
+++ b/src/app/app.pro
@@ -397,7 +397,20 @@ macx {
 unix:!macx {
     target.path = $$PREFIX/bin
 
-    metainfo.files = XDGData/io.github.maurycyliebner.enve.metainfo.xml
+    isEmpty(LATEST_COMMIT_HASH) {
+        METAINFO_RELEASE_VERSION = $$ENVE_VERSION
+        METAINFO_RELEASE_DATE = $$system(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%d" 2>/dev/null || date -u -r "${SOURCE_DATE_EPOCH:-$(date +%s)}" "+%Y-%m-%d")
+    } else {
+        METAINFO_RELEASE_VERSION = $$ENVE_VERSION-$$LATEST_COMMIT_HASH
+        METAINFO_RELEASE_DATE = $$LATEST_COMMIT_DATE
+    }
+
+    metainfo_in = $$cat(XDGData/io.github.maurycyliebner.enve.metainfo.xml.in, blob)
+    metainfo_in = $$replace(metainfo_in, @METAINFO_RELEASE_VERSION@, $$METAINFO_RELEASE_VERSION)
+    metainfo_in = $$replace(metainfo_in, @METAINFO_RELEASE_DATE@, $$METAINFO_RELEASE_DATE)
+    write_file($$OUT_PWD/io.github.maurycyliebner.enve.metainfo.xml, metainfo_in)
+
+    metainfo.files = $$OUT_PWD/io.github.maurycyliebner.enve.metainfo.xml
     metainfo.path = $$PREFIX/share/metainfo
 
     desktop.files = XDGData/enve.desktop

--- a/src/core/ReadWrite/filefooter.cpp
+++ b/src/core/ReadWrite/filefooter.cpp
@@ -5,7 +5,7 @@
 
 char FileFooter::sEVFormat[15] = "enve ev";
 char FileFooter::sAppName[15] = "enve";
-char FileFooter::sAppVersion[15] = "0.0.0c";
+char FileFooter::sAppVersion[15] = ENVE_VERSION;
 
 void FileFooter::sWrite(eWriteStream& dst) {
     dst << EvFormat::version;

--- a/src/core/core.pri
+++ b/src/core/core.pri
@@ -1,3 +1,15 @@
+ENVE_VERSION = 0.0.0c
+
+DEFINES += ENVE_VERSION=\\\"$$ENVE_VERSION\\\"
+
+exists(../../.git/index) {
+    LATEST_COMMIT_HASH = $$system(git log --pretty=format:'%h' -n 1)
+    LATEST_COMMIT_DATE = $$system(git log -1 --pretty=%cd --date=short)
+
+    DEFINES += LATEST_COMMIT_HASH=\\\"$$LATEST_COMMIT_HASH\\\"
+    DEFINES += LATEST_COMMIT_DATE=\\\"$$LATEST_COMMIT_DATE\\\"
+}
+
 # Header for third-party dependencies
 
 ENVE_FOLDER = $$_PRO_FILE_PWD_/../..


### PR DESCRIPTION
* run `git` from qmake
* define `ENVE_VERSION`
* update `io.github.maurycyliebner.enve.metainfo.xml.in` automatically


(This `$$system(date...)` line was taken from https://github.com/mltframework/shotcut/commit/3c8f204ac913b39d83cd2439d13480c8dd6aadf3.)