### PR TITLE
Changed the height of the toolbar

### DIFF
--- a/src/app/GUI/mainwindow.cpp
+++ b/src/app/GUI/mainwindow.cpp
@@ -257,6 +257,9 @@ MainWindow::MainWindow(Document& document,
     connect(fsl, &FileSourceList::doubleClicked,
             this, &MainWindow::importFile);
 
+
+
+
     {
         const auto brush = BrushCollectionData::sGetBrush("Deevad", "2B_pencil");
         const auto paintCtxt = BrushSelectionWidget::sPaintContext;
@@ -1026,7 +1029,7 @@ void MainWindow::setupToolBar() {
     mActionNewEmptyPaintFrameAct = mToolBar->addWidget(mActionNewEmptyPaintFrame);
 
     eSizesUI::widget.add(mToolBar, [this](const int size) {
-        mToolBar->setFixedHeight(2*size);
+        mToolBar->setMinimumHeight(2*size);
     });
 
     addToolBar(mToolBar);


### PR DESCRIPTION
This change resolves the problem of displaying the tools in this panel when you are working on a low-resolution monitor. The panel height now adapts to the height. But the solution is not perfect.
before
![old](https://user-images.githubusercontent.com/65244629/126895594-0a3a071d-e05f-4725-91cd-ef8baf969c78.png)
after
![тттт](https://user-images.githubusercontent.com/65244629/126895534-9be714a9-0cba-400b-aa65-179bf14efaef.png)
